### PR TITLE
fix: Make LegalGapDB logo clickable with correct homepage URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,10 @@
             <div class="flex justify-between h-16">
                 <div class="flex items-center">
                     <div class="flex-shrink-0 flex items-center">
-                        <span class="text-2xl mr-2">⚖️</span>
-                        <span class="font-bold text-xl text-legal-blue">LegalGapDB</span>
+                        <a href="https://adrianlerer.github.io/LegalGapDB/" class="flex items-center hover:opacity-80 transition-opacity">
+                            <span class="text-2xl mr-2">⚖️</span>
+                            <span class="font-bold text-xl text-legal-blue">LegalGapDB</span>
+                        </a>
                     </div>
                     <div class="hidden md:ml-10 md:flex space-x-8">
                         <a href="#home" class="text-gray-700 hover:text-legal-blue px-3 py-2 text-sm font-medium">Home</a>
@@ -444,8 +446,10 @@
             <div class="grid md:grid-cols-4 gap-8">
                 <div>
                     <div class="flex items-center mb-4">
-                        <span class="text-2xl mr-2">⚖️</span>
-                        <span class="font-bold text-xl">LegalGapDB</span>
+                        <a href="https://adrianlerer.github.io/LegalGapDB/" class="flex items-center hover:opacity-80 transition-opacity">
+                            <span class="text-2xl mr-2">⚖️</span>
+                            <span class="font-bold text-xl">LegalGapDB</span>
+                        </a>
                     </div>
                     <p class="text-gray-300 mb-4">
                         Building Legal AI that works for 88% of humanity, not just the WEIRD 12%.


### PR DESCRIPTION
- Added clickable links to both header and footer logos
- Links point to https://adrianlerer.github.io/LegalGapDB/
- Added hover effects for better UX
- Fixes issue where logo was not clickable